### PR TITLE
Fix build with C++14 && --march=native

### DIFF
--- a/sdk/src/hal/types.h
+++ b/sdk/src/hal/types.h
@@ -77,9 +77,6 @@ typedef _u32            _word_size_t;
 
 
 
-#define __le 
-#define __be
-
 #define _multi_thread
 #define _single_thread
 


### PR DESCRIPTION
Fix build with C++14 && --march=native flags on Intel Core i7

I have the build problem if I try to build rplidar_ros with the following flags on my system:

`catkin build --cmake-args -DCMAKE_CXX_STANDARD=14 -DCMAKE_CXX_FLAGS=-march=native -DCMAKE_C_FLAGS=-march=native -DCMAKE_BUILD_TYPE=Release`

The compiler shows some errors like this:

![изображение](https://user-images.githubusercontent.com/8876827/55402985-69fcb780-555d-11e9-955a-a5dabaaa48bb.png)

I spent some time on this and I found a solution:

rplidar_ros has two unused defines __le and __be macros. They overwrite names of local varibales in standard includes that leads us to compliation fail. I didn't find any place where that macro (__le and __be) are used. I decide to delete them. 

Please approve this PR if I am right. 

Thank you. 