### PR TITLE
fixed out of range indexing for angle_compensate

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -334,7 +334,12 @@ int main(int argc, char * argv[]) {
                             int angle_value = (int)(angle * angle_compensate_multiple);
                             if ((angle_value - angle_compensate_offset) < 0) angle_compensate_offset = angle_value;
                             for (j = 0; j < angle_compensate_multiple; j++) {
-                                angle_compensate_nodes[angle_value-angle_compensate_offset+j] = nodes[i];
+                                int index = angle_value - angle_compensate_offset + j;
+                                if (index >= angle_compensate_nodes_count) {
+                                        //ROS_WARN("skipping out of range compensate index %d for i %d",index,i);
+                                        continue;
+                                }
+                                angle_compensate_nodes[index] = nodes[i];
                             }
                         }
                     }


### PR DESCRIPTION
Hi,
We encoutered issues on A3 with angle_compensate active in Sensitivity mode (and other non 360 array sizes). Basically the indexing goes out of range, causing some random crashes on Raspberry Pi for instance, especially when LIDAR has all points valid (non 0). It worked fine on x86 architectures, but  still goes out of range and may cause some random bugs.
The patch simply skips points that are out of the array. I tried to make sense of the angle_compensate calculations, but I'm not sure what it's exactly supposed to do, also it seems pretty inefficient, overwriting the same array cells multiple times.
