### PR TITLE
add launch file arguments for configurability

### DIFF
--- a/launch/rplidar.launch
+++ b/launch/rplidar.launch
@@ -1,10 +1,17 @@
 <launch>
+  <arg name="serial_port"         default="/dev/ttyUSB0"/>
+  <arg name="serial_baudrate"     default="115200"/><!--A1/A2 -->
+  <!--param name="serial_baudrate"     default="256000"--><!--A3 -->
+  <arg name="frame_id"            default="laser"/>
+  <arg name="inverted"            default="false"/>
+  <arg name="angle_compensate"    default="true"/>
+  
   <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" output="screen">
-  <param name="serial_port"         type="string" value="/dev/ttyUSB0"/>
-  <param name="serial_baudrate"     type="int"    value="115200"/><!--A1/A2 -->
-  <!--param name="serial_baudrate"     type="int"    value="256000"--><!--A3 -->
-  <param name="frame_id"            type="string" value="laser"/>
-  <param name="inverted"            type="bool"   value="false"/>
-  <param name="angle_compensate"    type="bool"   value="true"/>
+    <param name="serial_port"         type="string" value="$(arg serial_port)"/>
+    <param name="serial_baudrate"     type="int"    value="$(arg serial_baudrate)"/><!--A1/A2 -->
+    <!--param name="serial_baudrate"     type="int"    value="$(arg serial_baudrate)"--><!--A3 -->
+    <param name="frame_id"            type="string" value="$(arg frame_id)"/>
+    <param name="inverted"            type="bool"   value="$(arg inverted)"/>
+    <param name="angle_compensate"    type="bool"   value="$(arg angle_compensate)"/>
   </node>
 </launch>


### PR DESCRIPTION
example use: serial_port:=/dev/ttyUSB1 when there are multiple serial devices

If you find these changes useful, I could apply them to the other launch files too.