### PR TITLE
fix missing std_srv dependency when compiling in isolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ FILE(GLOB RPLIDAR_SDK_SRC
 )
 
 find_package(catkin REQUIRED COMPONENTS
+  std_srvs
   roscpp
   rosconsole
   sensor_msgs


### PR DESCRIPTION
when compiling with catkin_build_isolated or build tools, std_srvs dependency was missing