### PR TITLE
Add simple parameter- and service-based speed control via motor PWM (for A2 and A3 only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,15 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-catkin_package()
+catkin_package(CATKIN_DEPENDS message_runtime)
 
 add_executable(rplidarNode src/node.cpp ${RPLIDAR_SDK_SRC})
 target_link_libraries(rplidarNode ${catkin_LIBRARIES})
 
 add_executable(rplidarNodeClient src/client.cpp)
 target_link_libraries(rplidarNodeClient ${catkin_LIBRARIES})
+
+add_dependencies(rplidarNode ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS rplidarNode rplidarNodeClient
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,15 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
   sensor_msgs
+  message_generation
 )
+
+add_service_files(
+  FILES
+  MotorSpeed.srv
+)
+
+generate_messages()
 
 include_directories(
   ${RPLIDAR_SDK_PATH}/include

--- a/package.xml
+++ b/package.xml
@@ -16,5 +16,7 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
+  <build_depend>message_generation</build_depend>
+  <run_depend>message_runtime</run_depend>
 
 </package>

--- a/srv/MotorSpeed.srv
+++ b/srv/MotorSpeed.srv
@@ -1,0 +1,2 @@
+uint16 speed
+---


### PR DESCRIPTION
I added a .srv file (and added message generation support to package.xml and CMakeLists.txt) for service-based speed changes, and added a motor_speed parameter to set the device's pwm at startup, for a personal project.
I put this pull request up for anyone needing these features.