### PR TITLE
Add static cast to avoid narrowing error

### DIFF
--- a/sdk/src/sl_lidar_driver.cpp
+++ b/sdk/src/sl_lidar_driver.cpp
@@ -551,7 +551,7 @@ namespace sl {
        
         sl_result grabScanDataHq(sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& count, sl_u32 timeout = DEFAULT_TIMEOUT)
         {
-            switch (_dataEvt.wait(timeout))
+            switch (static_cast<int>(_dataEvt.wait(timeout)))
             {
             case rp::hal::Event::EVENT_TIMEOUT:
                 count = 0;


### PR DESCRIPTION
Dear maintainers,

As happened to @sai5555 in #56, I got this error building rplidar_ros from sources (Noetic, g++ (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0):

```
/home/fmrico/ros/ros1/robots_ws/src/ThirdParty/rplidar_ros/sdk/src/sl_lidar_driver.cpp:556:34: error: narrowing conversion of ‘rp::hal::Event::EVENT_TIMEOUT’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
  556 |             case rp::hal::Event::EVENT_TIMEOUT:
```

This PR contains a simple fix for this.

I hope it helps
