### PR TITLE
Fix narrowing int to unsigned long issue

### DIFF
--- a/sdk/src/hal/event.h
+++ b/sdk/src/hal/event.h
@@ -95,7 +95,7 @@ public:
         }
     }
     
-    unsigned long wait( unsigned long timeout = 0xFFFFFFFF )
+    int wait( unsigned long timeout = 0xFFFFFFFF )
     {
 #ifdef _WIN32
         switch (WaitForSingleObject(_event, timeout==0xFFFFFFF?INFINITE:(DWORD)timeout))


### PR DESCRIPTION
replace wait() function return type from unsigned long to int to match
the enum values it returns (current possible values are -1 0 and 1)

Fixes Slamtec/rplidar_ros#56