### PR TITLE
pointer cast fix for (error: ordered comparison of pointer with integer zero)

### DIFF
--- a/sdk/src/arch/linux/net_socket.cpp
+++ b/sdk/src/arch/linux/net_socket.cpp
@@ -19,7 +19,7 @@
 namespace rp{ namespace net {
 
 
-static inline int _halAddrTypeToOSType(SocketAddress::address_type_t type) 
+static inline int _halAddrTypeToOSType(SocketAddress::address_type_t type)
 {
     switch (type) {
         case SocketAddress::ADDRESS_TYPE_INET:
@@ -36,11 +36,11 @@ static inline int _halAddrTypeToOSType(SocketAddress::address_type_t type)
 }
 
 
-SocketAddress::SocketAddress() 
+SocketAddress::SocketAddress()
 {
     _platform_data = reinterpret_cast<void *>(new sockaddr_storage);
     memset(_platform_data, 0, sizeof(sockaddr_storage));
-    
+
     reinterpret_cast<sockaddr_storage *>(_platform_data)->ss_family = AF_INET;
 }
 
@@ -56,7 +56,7 @@ SocketAddress::SocketAddress(const char * addrString, int port, SocketAddress::a
 {
     _platform_data = reinterpret_cast<void *>(new sockaddr_storage);
     memset(_platform_data, 0, sizeof(sockaddr_storage));
-    
+
     // default to ipv4 in case the following operation fails
     reinterpret_cast<sockaddr_storage *>(_platform_data)->ss_family = AF_INET;
 
@@ -127,17 +127,17 @@ u_result SocketAddress::setAddressFromString(const char * address_string,  Socke
     switch (type) {
         case ADDRESS_TYPE_INET:
             reinterpret_cast<sockaddr_storage *>(_platform_data)->ss_family = AF_INET;
-            ans = inet_pton(AF_INET, 
-                            address_string, 
+            ans = inet_pton(AF_INET,
+                            address_string,
                             &reinterpret_cast<sockaddr_in *>(_platform_data)->sin_addr);
         break;
 
 
         case ADDRESS_TYPE_INET6:
-            
+
             reinterpret_cast<sockaddr_storage *>(_platform_data)->ss_family = AF_INET6;
-            ans = inet_pton(AF_INET6, 
-                            address_string, 
+            ans = inet_pton(AF_INET6,
+                            address_string,
                             &reinterpret_cast<sockaddr_in6  *>(_platform_data)->sin6_addr);
         break;
 
@@ -167,7 +167,7 @@ u_result SocketAddress::getAddressAsString(char * buffer, size_t buffersize) con
 
         break;
     }
-    return ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
+    return ((uintptr_t)ans)<=0?RESULT_OPERATION_FAIL:RESULT_OK;
 }
 
 
@@ -184,7 +184,7 @@ size_t SocketAddress::LoopUpHostName(const char * hostname, const char * sevicen
 
     if (!performDNS) {
         hints.ai_family |= AI_NUMERICSERV | AI_NUMERICHOST;
-    
+
     }
 
     ans = getaddrinfo(hostname, sevicename, &hints, &result);
@@ -196,7 +196,7 @@ size_t SocketAddress::LoopUpHostName(const char * hostname, const char * sevicen
         return 0;
     }
 
-    
+
     for (struct addrinfo * cursor = result; cursor != NULL; cursor = cursor->ai_next) {
         if (cursor->ai_family == ADDRESS_TYPE_INET || cursor->ai_family == ADDRESS_TYPE_INET6) {
             sockaddr_storage * storagebuffer = new sockaddr_storage;
@@ -206,7 +206,7 @@ size_t SocketAddress::LoopUpHostName(const char * hostname, const char * sevicen
         }
     }
 
-    
+
     freeaddrinfo(result);
 
     return addresspool.size();
@@ -221,7 +221,7 @@ u_result SocketAddress::getRawAddress(_u8 * buffer, size_t bufferSize) const
 
             memcpy(buffer, &reinterpret_cast<const sockaddr_in *>(_platform_data)->sin_addr.s_addr, sizeof(reinterpret_cast<const sockaddr_in *>(_platform_data)->sin_addr.s_addr));
 
-            
+
             break;
         case ADDRESS_TYPE_INET6:
             if (bufferSize < sizeof(in6_addr::s6_addr)) return RESULT_INSUFFICIENT_MEMORY;
@@ -309,7 +309,7 @@ void SocketAddress::setAnyAddress(SocketAddress::address_type_t type)
 ///--------------------------------
 
 
-namespace rp { namespace arch { namespace net{ 
+namespace rp { namespace arch { namespace net{
 
 using namespace rp::net;
 
@@ -328,7 +328,7 @@ public:
         this->setTimeout(DEFAULT_SOCKET_TIMEOUT, SOCKET_DIR_BOTH);
     }
 
-    virtual ~StreamSocketImpl() 
+    virtual ~StreamSocketImpl()
     {
         close(_socket_fd);
     }
@@ -369,8 +369,8 @@ public:
     {
         int ans;
         timeval tv;
-        tv.tv_sec = timeout / 1000; 
-        tv.tv_usec = (timeout % 1000) * 1000; 
+        tv.tv_sec = timeout / 1000;
+        tv.tv_usec = (timeout % 1000) * 1000;
 
         if (msk & SOCKET_DIR_RD) {
              ans = ::setsockopt( _socket_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv) );
@@ -384,7 +384,7 @@ public:
 
         return RESULT_OK;
     }
-  
+
     virtual u_result connect(const SocketAddress & pairAddress)
     {
         const struct sockaddr * addr = reinterpret_cast<const struct sockaddr *>(pairAddress.getPlatformData());
@@ -405,7 +405,7 @@ public:
                 return RESULT_OPERATION_FAIL;
         }
     }
-      
+
     virtual u_result listen(int backlog)
     {
         int ans = ::listen( _socket_fd,   backlog);
@@ -413,7 +413,7 @@ public:
         return ans?RESULT_OPERATION_FAIL:RESULT_OK;
     }
 
-    virtual StreamSocket * accept(SocketAddress * pairAddress) 
+    virtual StreamSocket * accept(SocketAddress * pairAddress)
     {
         size_t addrsize;
         addrsize = sizeof(sockaddr_storage);
@@ -432,7 +432,7 @@ public:
         return waitforData(timeout);
     }
 
-    virtual u_result send(const void * buffer, size_t len) 
+    virtual u_result send(const void * buffer, size_t len)
     {
         size_t ans = ::send( _socket_fd, buffer, len, MSG_NOSIGNAL);
         if (ans == (int)len) {
@@ -448,7 +448,7 @@ public:
                     return RESULT_OPERATION_FAIL;
             }
         }
-        
+
     }
 
 
@@ -456,7 +456,7 @@ public:
     {
         size_t ans = ::recv( _socket_fd, buf, len, 0);
         if (ans == (size_t)-1) {
-            recv_len = 0;  
+            recv_len = 0;
 
             switch (errno) {
                 case EAGAIN:
@@ -468,7 +468,7 @@ public:
                     return RESULT_OPERATION_FAIL;
             }
 
-            
+
 
         } else {
             recv_len = ans;
@@ -481,9 +481,9 @@ public:
     {
         size_t ans = ::recv( _socket_fd, buf, len, MSG_DONTWAIT);
         if (ans == (size_t)-1) {
-            recv_len = 0;  
+            recv_len = 0;
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                return RESULT_OK; 
+                return RESULT_OK;
             } else {
                 return RESULT_OPERATION_FAIL;
             }
@@ -537,13 +537,13 @@ public:
         return ::setsockopt( _socket_fd, SOL_SOCKET, SO_KEEPALIVE , &bool_true, sizeof(bool_true) )?RESULT_OPERATION_FAIL:RESULT_OK;
     }
 
-    virtual u_result enableNoDelay(bool enable ) 
+    virtual u_result enableNoDelay(bool enable )
     {
         int bool_true = enable?1:0;
         return ::setsockopt( _socket_fd, IPPROTO_TCP, TCP_NODELAY,&bool_true, sizeof(bool_true) )?RESULT_OPERATION_FAIL:RESULT_OK;
     }
 
-    virtual u_result waitforSent(_u32 timeout ) 
+    virtual u_result waitforSent(_u32 timeout )
     {
         fd_set wrset;
         FD_ZERO(&wrset);
@@ -611,7 +611,7 @@ public:
         setTimeout(DEFAULT_SOCKET_TIMEOUT, SOCKET_DIR_BOTH);
     }
 
-    virtual ~DGramSocketImpl() 
+    virtual ~DGramSocketImpl()
     {
         close(_socket_fd);
     }
@@ -652,8 +652,8 @@ public:
     {
         int ans;
         timeval tv;
-        tv.tv_sec = timeout / 1000; 
-        tv.tv_usec = (timeout % 1000) * 1000; 
+        tv.tv_sec = timeout / 1000;
+        tv.tv_usec = (timeout % 1000) * 1000;
 
         if (msk & SOCKET_DIR_RD) {
              ans = ::setsockopt( _socket_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv) );
@@ -667,9 +667,9 @@ public:
 
         return RESULT_OK;
     }
-  
 
-    virtual u_result waitforSent(_u32 timeout ) 
+
+    virtual u_result waitforSent(_u32 timeout )
     {
         fd_set wrset;
         FD_ZERO(&wrset);
@@ -738,7 +738,7 @@ public:
                 default:
                     return RESULT_OPERATION_FAIL;
             }
-        
+
         }
 
     }
@@ -761,7 +761,7 @@ public:
 
         size_t ans = ::recvfrom( _socket_fd, buf, len, 0, addr, (socklen_t*)&source_addr_size);
         if (ans == (size_t)-1) {
-            recv_len = 0;  
+            recv_len = 0;
             switch (errno) {
                 case EAGAIN:
 #if EWOULDBLOCK!=EAGAIN
@@ -789,9 +789,9 @@ public:
         size_t ans = ::recvfrom( _socket_fd, buf, len, MSG_DONTWAIT, addr, &source_addr_size);
 
         if (ans == (size_t)-1) {
-            recv_len = 0;  
+            recv_len = 0;
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                return RESULT_OK; 
+                return RESULT_OK;
             } else {
                 return RESULT_OPERATION_FAIL;
             }
@@ -804,7 +804,7 @@ public:
 
     }
 #endif
-    
+
 protected:
     int  _socket_fd;
 
@@ -814,7 +814,7 @@ protected:
 }}}
 
 
-namespace rp { namespace net{ 
+namespace rp { namespace net{
 
 
 static inline int _socketHalFamilyToOSFamily(SocketBase::socket_family_t family)
@@ -863,4 +863,3 @@ DGramSocket * DGramSocket::CreateSocket(SocketBase::socket_family_t family)
 
 
 }}
-


### PR DESCRIPTION
Found this bug when running at Ubuntu 21.10, same as @[sai5555](https://github.com/sai5555) https://github.com/Slamtec/rplidar_ros/issues/56#issue-929377173
The error:
[https://disk.yandex.ru/i/1A5TNNlLATezGA](url)

can be fixed in the line 170 of rplidar_ros/sdk/src/arch/linux/net_socket.cpp
`return ((uintptr_t)ans)<=0?RESULT_OPERATION_FAIL:RESULT_OK;`