### PR TITLE
Fix Compilation error (narrowing conversion)

### DIFF
--- a/sdk/src/hal/event.h
+++ b/sdk/src/hal/event.h
@@ -95,7 +95,7 @@ public:
         }
     }
     
-    unsigned long wait( unsigned long timeout = 0xFFFFFFFF )
+    int wait( unsigned long timeout = 0xFFFFFFFF )
     {
 #ifdef _WIN32
         switch (WaitForSingleObject(_event, timeout==0xFFFFFFF?INFINITE:(DWORD)timeout))
@@ -109,7 +109,7 @@ public:
         }
         return EVENT_OK;
 #else
-        unsigned long ans = EVENT_OK;
+        int ans = EVENT_OK;
         pthread_mutex_lock( &_cond_locker );
 
         if ( !_is_signalled )


### PR DESCRIPTION
As happened in  #85, I got this error building rplidar_ros from sources:
`/home/pi/catkin_ws/src/rplidar_ros/sdk/src/sl_lidar_driver.cpp:556:34: error: narrowing conversion of ‘rp::hal::Event::EVENT_TIMEOUT’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
  556 |             case rp::hal::Event::EVENT_TIMEOUT:`
This PR contains a simple fix by changing the return types and variables related to events from unsigned long to int in event.h file.