### PR TITLE
Fixing for ROS2 Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-narrowing)
 endif()
 
 if(MSVC)

--- a/src/rplidar_scan_publisher.cpp
+++ b/src/rplidar_scan_publisher.cpp
@@ -64,25 +64,25 @@ class RPLidarScanPublisher : public rclcpp::Node
   private:    
     void init_param()
     {
-        this->declare_parameter("channel_type");
-        this->declare_parameter("tcp_ip");
-        this->declare_parameter("tcp_port");
-        this->declare_parameter("serial_port");
-        this->declare_parameter("serial_baudrate");
-        this->declare_parameter("frame_id");
-        this->declare_parameter("inverted");
-        this->declare_parameter("angle_compensate");
-        this->declare_parameter("scan_mode");
-
-        this->get_parameter_or<std::string>("channel_type", channel_type, "serial");
-        this->get_parameter_or<std::string>("tcp_ip", tcp_ip, "192.168.0.7"); 
-        this->get_parameter_or<int>("tcp_port", tcp_port, 20108);
-        this->get_parameter_or<std::string>("serial_port", serial_port, "/dev/ttyUSB0"); 
-        this->get_parameter_or<int>("serial_baudrate", serial_baudrate, 115200/*256000*/);//ros run for A1 A2, change to 256000 if A3
-        this->get_parameter_or<std::string>("frame_id", frame_id, "laser_frame");
-        this->get_parameter_or<bool>("inverted", inverted, false);
-        this->get_parameter_or<bool>("angle_compensate", angle_compensate, false);
-        this->get_parameter_or<std::string>("scan_mode", scan_mode, std::string());
+        this->declare_parameter("channel_type", "serial");
+        this->declare_parameter("tcp_ip", "192.168.0.7");
+        this->declare_parameter("tcp_port", 20108);
+        this->declare_parameter("serial_port", "/dev/ttyUSB0");
+        this->declare_parameter("serial_baudrate", 115200); //ros run for A1 A2, change to 256000 if A3
+        this->declare_parameter("frame_id", "laser_frame");
+        this->declare_parameter("inverted", false);
+        this->declare_parameter("angle_compensate", false);
+        this->declare_parameter("scan_mode", "");
+        
+        this->get_parameter<std::string>("channel_type", channel_type);
+        this->get_parameter<std::string>("tcp_ip", tcp_ip); 
+        this->get_parameter<int>("tcp_port", tcp_port);
+        this->get_parameter<std::string>("serial_port", serial_port); 
+        this->get_parameter<int>("serial_baudrate", serial_baudrate);
+        this->get_parameter<std::string>("frame_id", frame_id);
+        this->get_parameter<bool>("inverted", inverted);
+        this->get_parameter<bool>("angle_compensate", angle_compensate);
+        this->get_parameter<std::string>("scan_mode", scan_mode);
     }
 
     bool getRPLIDARDeviceInfo(RPlidarDriver * drv)


### PR DESCRIPTION
Due to changes in the [rclcpp node implementation](https://github.com/ros2/rclcpp/commit/24bb65305d47bf8562e2b38432bfb5ed248d9047), calling `declare_parameters` with only the parameter name is not valid anymore.