### PR TITLE
create_udev_rules.sh bug fix in ros2

### DIFF
--- a/scripts/create_udev_rules.sh
+++ b/scripts/create_udev_rules.sh
@@ -3,7 +3,8 @@
 echo "remap the device serial port(ttyUSBX) to  rplidar"
 echo "rplidar usb connection as /dev/rplidar , check it using the command : ls -l /dev|grep ttyUSB"
 echo "start copy rplidar.rules to  /etc/udev/rules.d/"
-colcon_cd rplidar_ros2
+source /usr/share/colcon_cd/function/colcon_cd.sh
+colcon_cd rplidar_ros
 sudo cp scripts/rplidar.rules  /etc/udev/rules.d
 echo " "
 echo "Restarting udev"


### PR DESCRIPTION
add command "source /usr/share/colcon_cd/function/colcon_cd.sh" to avoid user doesn't use colcon_cd before
correct repo name from rplidar_ros2 to rplidar_ros