### PR TITLE
Add initial_reset option to reset rplidar on node start

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -303,9 +303,20 @@ int main(int argc, char * argv[]) {
             ROS_ERROR("Error resetting rplidar");
             return -1;
         } else {
+            // wait for the rplidar to reset
+            ros::time last_time = ros::time::now();
+            while (!getRPLIDARDeviceInfo(drv)
+            {
+                ros::Duration(2).sleep();
+                if ( (ros::time::now() - last_time) > 10 )
+                {
+                    delete drv;
+                    ROS_ERROR("Error resetting rplidar");
+                    return -1;
+                }
+            }
+
             ROS_INFO("Rplidar successfully reset");
-            // let rplidar settle after reset
-            ros::Duration(2).sleep();
         }
     }
     if (!checkRPLIDARHealth(drv)) {


### PR DESCRIPTION
Add initial_reset option to reset rplidar on node start，and when node starts to reset rplidar, if rplidar info is not obtained within 10 seconds, rplidar reset fails