### PR TITLE
Install udev rules via debian.

### DIFF
--- a/debian/udev
+++ b/debian/udev
@@ -1,0 +1,4 @@
+# set the udev rule , make the device_port be fixed by rplidar
+#
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE:="0666", SYMLINK+="rplidar"
+


### PR DESCRIPTION
Adding this will automatically install the udev rules when the debian is generated.  Also, reduced the permissions. 