### PR TITLE
Add command to stop motor for S2 RPLidar

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -195,6 +195,7 @@ bool stop_motor(std_srvs::Empty::Request &req,
 
   ROS_DEBUG("Stop motor");
   drv->setMotorSpeed(0);
+  drv->stop();
   return true;
 }
 


### PR DESCRIPTION
Same changes that was made int he ROS2 version was added to this ROS1 commit.

Without it, we had a problem where RPLidar A series would stop like they should but S series would start automatically then never stop when the service was called.

fix #83 