### PR TITLE
Change a2m8 radar scan_mode from Sensitivity to Standard

### DIFF
--- a/launch/rplidar_a2m8_launch.py
+++ b/launch/rplidar_a2m8_launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     frame_id = LaunchConfiguration('frame_id', default='laser')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
-    scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    scan_mode = LaunchConfiguration('scan_mode', default='Standard')
     
     return LaunchDescription([
 

--- a/launch/view_rplidar_a2m8_launch.py
+++ b/launch/view_rplidar_a2m8_launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     frame_id = LaunchConfiguration('frame_id', default='laser')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
-    scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    scan_mode = LaunchConfiguration('scan_mode', default='Standard')
 	
     rviz_config_dir = os.path.join(
             get_package_share_directory('rplidar_ros'),


### PR DESCRIPTION
Model a2m8 radar cannot be started using the default Sensitivity scan_mode.