### PR TITLE
fixed "error: unknown type name 'nullptr_t'"

### DIFF
--- a/sdk/src/sl_async_transceiver.cpp
+++ b/sdk/src/sl_async_transceiver.cpp
@@ -201,7 +201,7 @@ u_result AsyncTransceiver::openChannelAndBind(IChannel* channel)
 		rp::hal::AutoLocker l(_opLocker);
 
         // try to open the channel ...
-        Result<nullptr_t> ans = SL_RESULT_OK;
+        Result<std::nullptr_t> ans = SL_RESULT_OK;
 
         if (!channel->open()) {
             ans= RESULT_OPERATION_FAIL;


### PR DESCRIPTION
when compiling i get the following error. " error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?"
using std::nullptr_t instead of nullptr_t fixes the issue