### PR TITLE
Add missing SDK dependencies for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(APPLE)
 add_compile_definitions(_MACOS)
 FILE(GLOB RPLIDAR_SDK_SRC
   "${RPLIDAR_SDK_PATH}/src/arch/macOS/*.cpp"
+  "${RPLIDAR_SDK_PATH}/src/dataunpacker/*.cpp"
+  "${RPLIDAR_SDK_PATH}/src/dataunpacker/unpacker/*.cpp"
   "${RPLIDAR_SDK_PATH}/src/hal/*.cpp"
   "${RPLIDAR_SDK_PATH}/src/*.cpp"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(MSVC)
   )
 endif()
 
-set(RPLIDAR_SDK_PATH "./sdk/")
+set(RPLIDAR_SDK_PATH "${PROJECT_SOURCE_DIR}/sdk/")
 
 if(APPLE)
 add_compile_definitions(_MACOS)


### PR DESCRIPTION
Add missing SDK dependencies for macOS. Resolves a link error caused by missing methods from the `dataunpacker` source.

Tested on macOS 15.2 (Sequoia), Xcode 16.2, ROS 2 Rolling with a RPLidar A1.

