### PR TITLE
edit view_rplidar_a1_launch.py scan mode - default='Sensitivity' does not work  

### DIFF
--- a/launch/view_rplidar_a1_launch.py
+++ b/launch/view_rplidar_a1_launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     frame_id = LaunchConfiguration('frame_id', default='laser')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
-    scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    scan_mode = LaunchConfiguration('scan_mode', default='Standard')
 	
     rviz_config_dir = os.path.join(
             get_package_share_directory('rplidar_ros'),


### PR DESCRIPTION
Line 20: scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity') This never worked on my rpi lidar A1. So i change it to Standard and then it works. I think that this should be the default:
 scan_mode = LaunchConfiguration('scan_mode', default='Standard')